### PR TITLE
Fix minor error number reporting

### DIFF
--- a/src/Bindings/HDF5/Error.hs
+++ b/src/Bindings/HDF5/Error.hs
@@ -63,7 +63,7 @@ readHDF5Error err = do
     return HDF5Error
         { classId       = ErrorClassID (h5e_error2_t'cls_id err)
         , majorNum      = majorErrorFromCode (h5e_error2_t'maj_num err)
-        , minorNum      = minorErrorFromCode (h5e_error2_t'maj_num err)
+        , minorNum      = minorErrorFromCode (h5e_error2_t'min_num err)
         , line          = toInteger (h5e_error2_t'line err)
         , funcName      = func
         , fileName      = file


### PR DESCRIPTION
Just fixed this on my fork -- as it stands all minor error codes are unknown because it's using the wrong value.

It seems you're probably the most active maintainer on this. I've been doing a little work on my fork for 1.10 compatibility, attributes, and minor other things. If you're interested I'd be happy to work on a merge of my other stuff and maybe get it up on hackage together.