### PR TITLE
Update bytestring and primitive upper bounds

### DIFF
--- a/hdf5.cabal
+++ b/hdf5.cabal
@@ -111,12 +111,12 @@ Library
 
   build-depends:        base >= 3 && < 5,
                         bindings-DSL >= 1.0.25 && < 1.1,
-                        bytestring >= 0.10.0 && < 0.12,
+                        bytestring >= 0.10.0 && < 0.13,
                         libffi >= 0.1 && < 0.3,
                         lifted-base >= 0.2.3 && < 0.3,
                         monad-control >= 1.0.3 && < 1.1,
                         transformers >= 0.5.0 && < 0.7,
-                        primitive >= 0.7.0 && < 0.9,
+                        primitive >= 0.7.0 && < 0.10,
                         tagged >= 0.8.0 && < 0.9,
                         vector >= 0.12.0 && < 0.14
 


### PR DESCRIPTION
This makes hdf5 workable with the latest stable nixpkgs which has bytestring-0.12 and primitive-0.9.

I've tested this change (did a `cabal build`) with ghc-9.8, 9.10 and 9.12 and it seems to work for all of those. Can you confirm, merge and release a new version?