### PR TITLE
Fix HDF5 < 1.12 compatibility in H5Oget_info bindings

### DIFF
--- a/src/Bindings/HDF5/Raw/H5O.hsc
+++ b/src/Bindings/HDF5/Raw/H5O.hsc
@@ -513,8 +513,8 @@ type H5O_iterate1_t a = H5O_iterate_t a
 -- H5Oget_info
 
 #if defined(H5Oget_info_vers)
-# ccall H5Oget_info1, <hid_t> -> Out <H5O_info1_t> -> IO <herr_t>
-# ccall H5Oget_info2, <hid_t> -> Out <H5O_info1_t> -> CUInt -> IO <herr_t>
+# ccall H5Oget_info1, <hid_t> -> Out <H5O_info_t> -> IO <herr_t>
+# ccall H5Oget_info2, <hid_t> -> Out <H5O_info_t> -> CUInt -> IO <herr_t>
 # if H5Oget_info_vers == 1
 h5o_get_info :: HId_t -> Out H5O_info_t -> IO HErr_t
 h5o_get_info = h5o_get_info1


### PR DESCRIPTION
FFI declarations for `H5Oget_info1` and `H5Oget_info2` incorrectly hardcoded `<H5O_info1_t>`. This breaks builds on HDF5 < 1.12 where `H5O_info_t_vers` is undefined and only `H5O_info_t` exists.

Aligning the signatures to `<H5O_info_t>` restores backwards compatibility. Forward compatibility for newer HDF5 versions is preserved via the existing `#synonym_t` macro.