### PR TITLE
Fix HAVE_DIRECT codepath

### DIFF
--- a/src/Bindings/HDF5/Raw/H5FD/Direct.hsc
+++ b/src/Bindings/HDF5/Raw/H5FD/Direct.hsc
@@ -9,6 +9,10 @@ module Bindings.HDF5.Raw.H5FD.Direct where
 import Bindings.HDF5.Raw.H5I
 #ifdef H5_HAVE_DIRECT
 import System.IO.Unsafe(unsafePerformIO)
+import Foreign.Ptr
+import Bindings.HDF5.Raw.H5
+import Foreign.C.Types
+import Foreign.Ptr.Conventions
 #endif /* H5_HAVE_DIRECT */
 
 #mangle_ident "H5FD_DIRECT"


### PR DESCRIPTION
When compiling with HDF5's "direct" feature enable, I get compilation errors because some imports are missing. This fixes it.